### PR TITLE
A fourth distribution flavor: Uber Jar for SpatialHadoop

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -86,7 +86,36 @@
         <include name="webapps/**/*"/>
       </fileset>
     </copy>
-  </target>	
+  </target>
+
+<!-- Group all dependencies into a big dependency-all.jar -->
+	<target name="copy-dependencies">
+	 
+		<mkdir dir="lib-dist" />
+		 
+		<jar jarfile="lib-dist/dependencies-all.jar">
+		<zipgroupfileset dir="lib/ivy/hadoop2">
+			<include name="**/*.jar" />
+		</zipgroupfileset>
+		<zipgroupfileset dir="lib/ivy/common">
+		         <include name="**/*.jar" />
+		</zipgroupfileset>
+		</jar>
+	</target>	
+
+<target name="copy-dependencies1">
+
+                <mkdir dir="lib-dist" />
+
+                <jar jarfile="lib-dist/dependencies-all.jar">
+                                <zipgroupfileset dir="lib/ivy/hadoop1">
+                                                        <include name="**/*.jar" />
+                                                                        </zipgroupfileset>
+                                                                                        <zipgroupfileset dir="lib/ivy/common">
+                                                                                                                 <include name="**/*.jar" />
+                                                                                                                                 </zipgroupfileset>
+                                                                                                                                                 </jar>
+                                                                                                                                                         </target>
 
 	<target name="doc" depends="init1"
       description="Generates JavaDoc for the source code">
@@ -94,7 +123,7 @@
     <javadoc sourcepath="${src}" destdir="${doc}"/>
   </target>
   
-  <target name="dist1" depends="compile1"
+  <target name="dist1" depends="compile1,copy-dependencies1"
         description="generate the distribution for Hadoop 1.x" >
     <!-- Create the distribution directory -->
     <mkdir dir="${dist1}"/>
@@ -105,6 +134,8 @@
         <attribute name="Manifest-Version" value="1.0"/>
         <attribute name="Main-Class" value="edu.umn.cs.spatialHadoop.operations.Main"/>
       </manifest>
+      <zipfileset src="lib-dist/dependencies-all.jar" 
+                                            excludes="META-INF/*.SF" />
   	</jar>
 
   	<!-- For backward compatibility, provide a jar that contains just the main class-->
@@ -117,7 +148,7 @@
   	</jar>
   </target>
 
-  <target name="dist2" depends="compile2"
+  <target name="dist2" depends="compile2,copy-dependencies"
         description="generate the distribution for Hadoop 2.x" >
     <!-- Create the distribution directory -->
     <mkdir dir="${dist2}"/>
@@ -128,6 +159,8 @@
         <attribute name="Manifest-Version" value="1.0"/>
         <attribute name="Main-Class" value="edu.umn.cs.spatialHadoop.operations.Main"/>
       </manifest>
+      <zipfileset src="lib-dist/dependencies-all.jar" 
+                                      excludes="META-INF/*.SF" />
     </jar>
 
     <!-- For backward compatibility, provide a jar that contains just the main class-->

--- a/ivy.xml
+++ b/ivy.xml
@@ -15,6 +15,7 @@
 	</configurations>
     
   <dependencies>
+<dependency org="javax.mail" name="mail" rev="1.4.7" conf="common->default" />
     <dependency org="org.apache.hadoop" name="hadoop-core" rev="1.2.1" conf="hadoop1->default"/>
     
     <dependency org="org.apache.hadoop" name="hadoop-common" rev="2.6.0" conf="hadoop2->default"/>

--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -1,0 +1,8 @@
+<ivysettings>
+    <settings defaultResolver="chain"/>
+    <resolvers>
+        <chain name="chain">
+	    <ibiblio name="securedcentral" m2compatible="true" root="https://repo1.maven.org/maven2" />
+        </chain>
+    </resolvers>
+</ivysettings>

--- a/src/edu/umn/cs/spatialHadoop/core/SpatialSite.java
+++ b/src/edu/umn/cs/spatialHadoop/core/SpatialSite.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -444,7 +445,9 @@ public class SpatialSite {
     
     fs.deleteOnExit(tempFile);
 
+ // tqadah: for hadoop-2.2
     DistributedCache.addCacheFile(tempFile.toUri(), conf);
+    LOG.info("adding to distributedCache : "+tempFile.toString());
     conf.set(OUTPUT_CELLS, tempFile.getName());
     LOG.info("Partitioning file into "+cellsInfo.length+" cells");
   }
@@ -461,21 +464,44 @@ public class SpatialSite {
     CellInfo[] cells = null;
     String cells_file = conf.get(OUTPUT_CELLS);
     if (cells_file != null) {
+      
       Path[] cacheFiles = DistributedCache.getLocalCacheFiles(conf);
-      for (Path cacheFile : cacheFiles) {
-        if (cacheFile.getName().contains(cells_file)) {
-          FSDataInputStream in = FileSystem.getLocal(conf).open(cacheFile);
-          
-          int cellCount = in.readInt();
-          cells = new CellInfo[cellCount];
-          for (int i = 0; i < cellCount; i++) {
-            cells[i] = new CellInfo();
-            cells[i].readFields(in);
+      
+      if (cacheFiles == null){
+        URI[] uris = DistributedCache.getCacheFiles(conf);
+        for (URI uri : uris) {
+          LOG.info("found in distcache : " + uri.getPath());
+          if (uri.getPath().contains(cells_file)) {
+            FSDataInputStream in = FileSystem.getLocal(conf).open(new Path(uri));
+            
+            int cellCount = in.readInt();
+            cells = new CellInfo[cellCount];
+            for (int i = 0; i < cellCount; i++) {
+              cells[i] = new CellInfo();
+              cells[i].readFields(in);
+            }
+            
+            in.close();
           }
-          
-          in.close();
         }
       }
+      else {
+        for (Path cacheFile : cacheFiles) {
+          if (cacheFile.getName().contains(cells_file)) {
+            FSDataInputStream in = FileSystem.getLocal(conf).open(cacheFile);
+            
+            int cellCount = in.readInt();
+            cells = new CellInfo[cellCount];
+            for (int i = 0; i < cellCount; i++) {
+              cells[i] = new CellInfo();
+              cells[i].readFields(in);
+            }
+            
+            in.close();
+          }
+        }
+      }
+      
     }
     return cells;
   }


### PR DESCRIPTION
The current SpatialHadoop distributions have three flavors as VM, as library installation, and bundled with Hadoop 1.2.1. However, all these distribution do not work when we don't have administrative privileges on the hadoop cluster. For example, the library installation, requires adding SpatialHadoop's files into Hadoop home which is not feasible in some cases. 

I would like to suggest a forth distribution flavor which is as an Uber Jar. Basically, a single jar file that includes all dependencies of SpatialHadoop and it can run when submitting the job. 

Example usage:

```
$ hadoop jar ./bin2/dist/spatialhadoop-2.3.jar generate test.rects size:1.gb shape:rect mbr:0,0,1000000,1000000 -overwrite
```

This is especially useful for developers who wish to extend SpatialHadoop and work with the source. 