### PR TITLE
 Resources should be closed

### DIFF
--- a/src/main/java/edu/umn/cs/spatialHadoop/util/FileUtil.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/util/FileUtil.java
@@ -18,6 +18,7 @@ import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -155,21 +156,19 @@ public final class FileUtil {
 	public static Path writePathsToFile(OperationsParams params, Path[] paths) {
 		String tmpFileName = "pathsDictionary.txt";
 		File tempFile;
+		BufferedWriter buffWriter = null;
 		try {
 			// store the dictionary of paths in a local file
 			tempFile = new File(tmpFileName);
 			Path localFilePath = new Path(tempFile.getAbsolutePath());
 			FileOutputStream outStream = new FileOutputStream(tempFile);
-			BufferedWriter buffWriter = new BufferedWriter(
+			buffWriter = new BufferedWriter(
 					new OutputStreamWriter(outStream));
 
 			for (int i = 0; i < paths.length; i++) {
 				buffWriter.write(paths[i].toString());
 				buffWriter.newLine();
 			}
-			buffWriter.close();
-			outStream.close();
-
 			// copy the local dictionary into an hdfs file
 			Configuration conf = new Configuration();
 			FileSystem fs = params.getPaths()[0].getFileSystem(conf);
@@ -182,6 +181,8 @@ public final class FileUtil {
 		} catch (IOException e) {
 			e.printStackTrace();
 			return null;
+		} finally {
+			IOUtils.closeQuietly(buffWriter);
 		}
 
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.