### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/main/java/edu/umn/cs/spatialHadoop/OperationsParams.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/OperationsParams.java
@@ -11,8 +11,8 @@ package edu.umn.cs.spatialHadoop;
 import java.awt.Color;
 import java.io.IOException;
 import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -116,7 +116,7 @@ public class OperationsParams extends Configuration {
 		// TODO if the argument shape is set to a class in a third party jar
 		// file
 		// add that jar file to the archives
-		Vector<Path> paths = new Vector<Path>();
+		List<Path> paths = new ArrayList<Path>();
 		for (String arg : args) {
 			String argl = arg.toLowerCase();
 			if (arg.startsWith("-no-")) {
@@ -603,7 +603,7 @@ public class OperationsParams extends Configuration {
 	 */
 	public boolean autoDetectShape() {
 		String autoDetectedShape = null;
-		final Vector<String> sampleLines = new Vector<String>();
+		final List<String> sampleLines = new ArrayList<String>();
 		if (this.get("shape") != null)
 			return true; // A shape is already configured
 		if (this.getInputPaths().length == 0)

--- a/src/main/java/edu/umn/cs/spatialHadoop/core/SpatialAlgorithms.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/core/SpatialAlgorithms.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 import java.util.TreeSet;
-import java.util.Vector;
+import java.util.ArrayList;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -718,7 +718,7 @@ public class SpatialAlgorithms {
       }
       List<Geometry> group = groups.get(root);
       if (group == null) {
-        group = new Vector<Geometry>();
+        group = new ArrayList<Geometry>();
         groups.put(root, group);
       }
       group.add(polygons[i]);

--- a/src/main/java/edu/umn/cs/spatialHadoop/delaunay/GSDTAlgorithm.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/delaunay/GSDTAlgorithm.java
@@ -921,8 +921,8 @@ public class GSDTAlgorithm {
 
   public boolean test() {
     final double threshold = 1E-6;
-    List<Point> starts = new Vector<Point>();
-    List<Point> ends = new Vector<Point>();
+    List<Point> starts = new ArrayList<Point>();
+    List<Point> ends = new ArrayList<Point>();
     for (int s1 = 0; s1 < points.length; s1++) {
       for (int s2 : neighbors[s1]) {
         if (s1 < s2) {

--- a/src/main/java/edu/umn/cs/spatialHadoop/indexing/Indexer.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/indexing/Indexer.java
@@ -15,6 +15,7 @@ import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -278,7 +279,7 @@ public class Indexer {
       FileSystem outFS = out.getFileSystem(job);
       long outBlockSize = outFS.getDefaultBlockSize(out);
 
-      final Vector<Point> sample = new Vector<Point>();
+      final List<Point> sample = new ArrayList<Point>();
       float sample_ratio = job.getFloat(SpatialSite.SAMPLE_RATIO, 0.01f);
       long sample_size = job.getLong(SpatialSite.SAMPLE_SIZE, 100 * 1024 * 1024);
 
@@ -326,7 +327,7 @@ public class Indexer {
     final String sindex = conf.get("sindex");
     
     // Start reading input file
-    Vector<InputSplit> splits = new Vector<InputSplit>();
+    List<InputSplit> splits = new ArrayList<InputSplit>();
     final SpatialInputFormat3<Rectangle, Shape> inputFormat = new SpatialInputFormat3<Rectangle, Shape>();
     FileSystem inFs = inPath.getFileSystem(conf);
     FileStatus inFStatus = inFs.getFileStatus(inPath);

--- a/src/main/java/edu/umn/cs/spatialHadoop/indexing/QuadTreePartitioner.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/indexing/QuadTreePartitioner.java
@@ -15,6 +15,8 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Queue;
 import java.util.Vector;
+import java.util.List;
+import java.util.ArrayList;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.FileSplit;
@@ -96,7 +98,7 @@ public class QuadTreePartitioner extends Partitioner {
     Queue<QuadTreeNode> nodesToSplit = new ArrayDeque<QuadTreeNode>();
     nodesToSplit.add(root);
 
-    Vector<Integer> leafNodeIDs = new Vector<Integer>();
+    List<Integer> leafNodeIDs = new ArrayList<Integer>();
     int maxNodeID = 0;
     
     while (!nodesToSplit.isEmpty()) {
@@ -263,7 +265,7 @@ public class QuadTreePartitioner extends Partitioner {
         new FileSplit(inPath, 0, length, new String[0]));
     Rectangle key = reader.createKey();
     ShapeIterator shapes = reader.createValue();
-    final Vector<Point> points = new Vector<Point>();
+    final List<Point> points = new ArrayList<Point>();
     while (reader.next(key, shapes)) {
       for (Shape s : shapes) {
         points.add(s.getMBR().getCenterPoint());

--- a/src/main/java/edu/umn/cs/spatialHadoop/indexing/RTree.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/indexing/RTree.java
@@ -17,9 +17,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Array;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Queue;
@@ -362,7 +364,7 @@ public class RTree<T extends Shape> implements Writable, Iterable<T>, Closeable 
       }
       
       // All nodes stored in level-order traversal
-      Vector<SplitStruct> nodes = new Vector<SplitStruct>();
+      List<SplitStruct> nodes = new ArrayList<SplitStruct>();
       final Queue<SplitStruct> toBePartitioned = new LinkedList<SplitStruct>();
       toBePartitioned.add(new SplitStruct(0, elementCount, SplitStruct.DIRECTION_X));
       
@@ -1063,8 +1065,8 @@ public class RTree<T extends Shape> implements Writable, Iterable<T>, Closeable 
     double query_radius = Math.sqrt(query_area / Math.PI);
 
     boolean result_correct;
-    final Vector<Double> distances = new Vector<Double>();
-    final Vector<T> shapes = new Vector<T>();
+    final List<Double> distances = new ArrayList<Double>();
+    final List<T> shapes = new ArrayList<T>();
     // Find results in the range and increase this range if needed to ensure
     // correctness of the answer
     do {

--- a/src/main/java/edu/umn/cs/spatialHadoop/mapred/BinarySpatialInputFormat.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/mapred/BinarySpatialInputFormat.java
@@ -93,7 +93,7 @@ public abstract class BinarySpatialInputFormat<K extends Writable, V extends Wri
       }
     }
     
-    final Vector<CombineFileSplit> matchedSplits = new Vector<CombineFileSplit>();
+    final List<CombineFileSplit> matchedSplits = new ArrayList<CombineFileSplit>();
     if (gIndexes[0] == null || gIndexes[1] == null) {
       // Join every possible pair (Cartesian product)
       InputSplit[][] inputSplits = new InputSplit[inputFiles.length][];

--- a/src/main/java/edu/umn/cs/spatialHadoop/mapred/CombineBlockFilter.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/mapred/CombineBlockFilter.java
@@ -8,6 +8,8 @@
 *************************************************************************/
 package edu.umn.cs.spatialHadoop.mapred;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 
 import org.apache.hadoop.conf.Configuration;
@@ -42,7 +44,7 @@ public class CombineBlockFilter extends DefaultBlockFilter {
   @Override
   public void selectCells(GlobalIndex<Partition> gIndex,
       ResultCollector<Partition> output) {
-    final Vector<Partition> selectedSoFar = new Vector<Partition>();
+    final List<Partition> selectedSoFar = new ArrayList<Partition>();
     // First block filter is applied directly to the global index
     blockFilters[0].selectCells(gIndex, new ResultCollector<Partition>() {
       @Override

--- a/src/main/java/edu/umn/cs/spatialHadoop/mapred/CombinedSpatialInputFormat.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/mapred/CombinedSpatialInputFormat.java
@@ -58,7 +58,7 @@ public class CombinedSpatialInputFormat<S extends Shape> extends
 			throws IOException {
 
 		final Path[] inputFiles = getInputPaths(job);
-		final Vector<InputSplit> combinedSplits = new Vector<InputSplit>();
+		final List<InputSplit> combinedSplits = new ArrayList<InputSplit>();
 		InputSplit[][] inputSplits = new InputSplit[inputFiles.length][];
 
 		@SuppressWarnings("unchecked")

--- a/src/main/java/edu/umn/cs/spatialHadoop/mapred/FileSplitUtil.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/mapred/FileSplitUtil.java
@@ -9,6 +9,7 @@
 package edu.umn.cs.spatialHadoop.mapred;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -57,7 +58,7 @@ public class FileSplitUtil {
       Path[] paths = new Path[count];
       long[] starts = new long[count];
       long[] lengths = new long[count];
-      Vector<String> vlocations = new Vector<String>();
+      List<String> vlocations = new ArrayList<String>();
       while (count > 0) {
         paths[count - 1] = splits.get(startIndex).getPath();
         starts[count - 1] = splits.get(startIndex).getStart();
@@ -95,7 +96,7 @@ public class FileSplitUtil {
       Path[] paths = new Path[count];
       long[] starts = new long[count];
       long[] lengths = new long[count];
-      Vector<String> vlocations = new Vector<String>();
+      List<String> vlocations = new ArrayList<String>();
       while (count > 0) {
         paths[count - 1] = splits.get(startIndex).getPath();
         starts[count - 1] = splits.get(startIndex).getStart();
@@ -127,7 +128,7 @@ public class FileSplitUtil {
     Path[] paths = new Path[2];
     long[] starts = new long[2];
     long[] lengths = new long[2];
-    Vector<String> vlocations = new Vector<String>();
+    List<String> vlocations = new ArrayList<String>();
     paths[0] = split1.getPath();
     starts[0] = split1.getStart();
     lengths[0] = split1.getLength();
@@ -226,7 +227,7 @@ public class FileSplitUtil {
     for (int i = 0; i < numSplits; i++) {
       // Decide how many splits to combine
       int numSplitsToCombine = splitsAvailable / (numSplits - i);
-      Vector<FileSplit> splitsToCombine = new Vector<FileSplit>();
+      List<FileSplit> splitsToCombine = new ArrayList<FileSplit>();
       while (numSplitsToCombine > 0) {
         // Choose the host with minimum number of splits
         Map.Entry<String, Vector<FileSplit>> minEntry = null;

--- a/src/main/java/edu/umn/cs/spatialHadoop/mapred/SpatialRecordReader.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/mapred/SpatialRecordReader.java
@@ -12,8 +12,10 @@ import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Vector;
 
 import org.apache.commons.logging.Log;
@@ -449,7 +451,7 @@ public abstract class SpatialRecordReader<K, V> implements RecordReader<K, V> {
    */
   protected boolean nextShapes(ArrayWritable shapes) throws IOException {
     // Prepare a vector that will hold all objects in this 
-    Vector<Shape> vshapes = new Vector<Shape>();
+    List<Shape> vshapes = new ArrayList<Shape>();
     try {
       Shape stockObject = (Shape) shapes.getValueClass().newInstance();
       // Reached the end of this split

--- a/src/main/java/edu/umn/cs/spatialHadoop/mapreduce/SpatialInputFormat3.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/mapreduce/SpatialInputFormat3.java
@@ -240,9 +240,9 @@ public class SpatialInputFormat3<K extends Rectangle, V extends Shape>
        * split, and each edge is weighted with number of shared hosts between
        * the two splits
        */
-      Vector<Vector<FileSplit>> openSplits = new Vector<Vector<FileSplit>>();
+      List<Vector<FileSplit>> openSplits = new ArrayList<Vector<FileSplit>>();
       int maxNumberOfSplits = (int) Math.ceil((float)splits.size() / combine);
-      List<InputSplit> combinedSplits = new Vector<InputSplit>();
+      List<InputSplit> combinedSplits = new ArrayList<InputSplit>();
       for (InputSplit split : splits) {
         FileSplit fsplit = (FileSplit) split;
         int maxSimilarity = -1; // Best similarity found so far

--- a/src/main/java/edu/umn/cs/spatialHadoop/nasa/AggregateQuadTree.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/nasa/AggregateQuadTree.java
@@ -19,9 +19,11 @@ import java.lang.reflect.Array;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Random;
@@ -107,7 +109,7 @@ class StockQuadTree {
     this.r = new int[resolution * resolution];
     final int[] z = new int[resolution * resolution];
     // The list of all nodes
-    Vector<Node> nodes = new Vector<Node>();
+    List<Node> nodes = new ArrayList<Node>();
     
     // Compute the Z-order of all values
     for (int i = 0; i < z.length; i++) {
@@ -769,9 +771,9 @@ public class AggregateQuadTree {
     int resolution = in.readInt();
     short fillValue = in.readShort();
     int cardinality = in.readInt();
-    final Vector<Integer> selectedNodesPos = new Vector<Integer>();
-    final Vector<Integer> selectedStarts = new Vector<Integer>();
-    final Vector<Integer> selectedEnds = new Vector<Integer>();
+    final List<Integer> selectedNodesPos = new ArrayList<Integer>();
+    final List<Integer> selectedStarts = new ArrayList<Integer>();
+    final List<Integer> selectedEnds = new ArrayList<Integer>();
     StockQuadTree stockQuadTree = getOrCreateStockQuadTree(resolution);
     // Nodes to be searched. Contains node positions in the array of nodes
     Stack<Integer> nodes_2b_searched = new Stack<Integer>();
@@ -932,7 +934,7 @@ public class AggregateQuadTree {
     FileStatus[] mathcingDays = timeRange == null?
         sourceFs.listStatus(inputDir) :
           sourceFs.listStatus(inputDir, timeRange);
-    final Vector<Path> sourceFiles = new Vector<Path>();
+    final List<Path> sourceFiles = new ArrayList<Path>();
     for (FileStatus matchingDay : mathcingDays) {
       for (FileStatus matchingTile : sourceFs.listStatus(matchingDay.getPath())) {
         sourceFiles.add(matchingTile.getPath());
@@ -1073,7 +1075,7 @@ public class AggregateQuadTree {
               };
 
               // Find matching tiles in all source indexes to merge
-              Vector<Path> filesToMerge = new Vector<Path>(lastIndex - firstIndex);
+              List<Path> filesToMerge = new ArrayList<Path>(lastIndex - firstIndex);
               filesToMerge.add(tileInFirstDay.getPath());
               for (int iDailyIndex = firstIndex + 1; iDailyIndex < lastIndex; iDailyIndex++) {
                 FileStatus[] matchedTileFile = fs.listStatus(sourceIndexes[iDailyIndex].getPath(), tileFilter);

--- a/src/main/java/edu/umn/cs/spatialHadoop/operations/ConvexHull.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/operations/ConvexHull.java
@@ -228,7 +228,7 @@ public class ConvexHull {
         ResultCollector<Partition> output) {
       Set<Partition> non_dominated_partitions_all = new HashSet<Partition>();
       for (OperationsParams.Direction dir : OperationsParams.Direction.values()) {
-        Vector<Partition> non_dominated_partitions = new Vector<Partition>();
+        List<Partition> non_dominated_partitions = new ArrayList<Partition>();
         for (Partition p : gIndex) {
           boolean dominated = false;
           int i = 0;
@@ -284,7 +284,7 @@ public class ConvexHull {
     public void reduce(NullWritable dummy, Iterator<Point> points,
         OutputCollector<NullWritable, Point> output, Reporter reporter)
         throws IOException {
-      Vector<Point> vpoints = new Vector<Point>();
+      List<Point> vpoints = new ArrayList<Point>();
       while (points.hasNext()) {
         vpoints.add(points.next().clone());
       }

--- a/src/main/java/edu/umn/cs/spatialHadoop/operations/Skyline.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/operations/Skyline.java
@@ -284,7 +284,7 @@ public class Skyline {
     @Override
     public void selectCells(GlobalIndex<Partition> gIndex,
         ResultCollector<Partition> output) {
-      Vector<Partition> non_dominated_partitions = new Vector<Partition>();
+      List<Partition> non_dominated_partitions = new ArrayList<Partition>();
       
       for (Partition p : gIndex) {
         boolean dominated = false;
@@ -349,7 +349,7 @@ public class Skyline {
     public void reduce(NullWritable dummy, Iterator<Point> points,
         OutputCollector<NullWritable, Point> output, Reporter reporter)
         throws IOException {
-      Vector<Point> vpoints = new Vector<Point>();
+      List<Point> vpoints = new ArrayList<Point>();
       while (points.hasNext()) {
         vpoints.add(points.next().clone());
       }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.