### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/edu/umn/cs/spatialHadoop/nasa/DistributedAggregateSpatioTemporalIndexer.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/nasa/DistributedAggregateSpatioTemporalIndexer.java
@@ -53,6 +53,9 @@ public class DistributedAggregateSpatioTemporalIndexer {
 
 	private static Path hdfsIndexPath = null;
 
+	private DistributedAggregateSpatioTemporalIndexer() {
+	}
+
 	public static class AggregateQuadTreeMaper extends MapReduceBase implements
 			Mapper<LongWritable, Text, Text, Text> {
 

--- a/src/main/java/edu/umn/cs/spatialHadoop/nasa/ImageCompare.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/nasa/ImageCompare.java
@@ -30,7 +30,10 @@ import org.apache.hadoop.fs.PathFilter;
  *
  */
 public class ImageCompare {
-  
+
+  private ImageCompare() {
+  }
+
   /**
    * Returns a similarity measure between two images on the scale from 0 to 1.
    * 0 indicates no similarity at all while 1 indicates exact similarity

--- a/src/main/java/edu/umn/cs/spatialHadoop/operations/FileMBR.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/operations/FileMBR.java
@@ -83,6 +83,9 @@ public class FileMBR {
   /**Last submitted MBR MapReduce job*/
   public static RunningJob lastSubmittedJob;
 
+  private FileMBR() {
+  }
+
   public static class FileMBRMapper extends MapReduceBase implements
       Mapper<Rectangle, Text, Text, Partition> {
     

--- a/src/main/java/edu/umn/cs/spatialHadoop/operations/LocalSampler.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/operations/LocalSampler.java
@@ -42,6 +42,9 @@ import edu.umn.cs.spatialHadoop.util.Parallel.RunnableRange;
  */
 public class LocalSampler {
 
+  private LocalSampler() {
+  }
+
   /**
    * Read a random sample of up-to count from the input files.
    * @param files

--- a/src/main/java/edu/umn/cs/spatialHadoop/util/FileUtil.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/util/FileUtil.java
@@ -42,6 +42,9 @@ import edu.umn.cs.spatialHadoop.nasa.HTTPFileSystem;
  */
 public final class FileUtil {
 
+	private FileUtil() {
+	}
+
 	public static String copyFile(Configuration job, FileStatus fileStatus)
 			throws IOException {
 		return FileUtil.copyFileSplit(job, new FileSplit(fileStatus.getPath(),

--- a/src/main/java/edu/umn/cs/spatialHadoop/util/NASADatasetUtil.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/util/NASADatasetUtil.java
@@ -21,10 +21,13 @@ import org.apache.hadoop.fs.PathFilter;
 
 /**
  * A bunch of helper functions used with NASA datasets (e.g. MODIS)
- * 
+ *
  * @author ibrahimsabek
  */
 public final class NASADatasetUtil {
+
+	private NASADatasetUtil() {
+	}
 
 	public static String extractDateStringFromFileStatus(FileStatus fileStatus) {
 		return NASADatasetUtil.extractDateStringFromPath(fileStatus.getPath());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.