### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/src/main/java/edu/umn/cs/spatialHadoop/core/GridInfo.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/core/GridInfo.java
@@ -70,7 +70,14 @@ public class GridInfo extends Rectangle {
     return super.equals(obj)
         && this.columns == gi.columns && this.rows == gi.rows;
   }
-  
+
+  @Override
+  public int hashCode() {
+    int result = this.columns;
+    result = 31 * result + this.rows;
+    return result;
+  }
+
   public void calculateCellDimensions(long totalFileSize, long blockSize) {
     // An empirical number for the expected overhead in grid file due to
     // replication

--- a/src/main/java/edu/umn/cs/spatialHadoop/core/Point.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/core/Point.java
@@ -76,7 +76,18 @@ public class Point implements Shape, Comparable<Point> {
 		Point r2 = (Point) obj;
 		return this.x == r2.x && this.y == r2.y;
 	}
-	
+
+	@Override
+	public int hashCode() {
+		int result;
+		long temp;
+		temp = Double.doubleToLongBits(this.x);
+		result = (int) (temp ^ temp >>> 32);
+		temp = Double.doubleToLongBits(this.y);
+		result = 31 * result + (int) (temp ^ temp >>> 32);
+		return result;
+	}
+
 	public double distanceTo(Point s) {
 		double dx = s.x - this.x;
 		double dy = s.y - this.y;

--- a/src/main/java/edu/umn/cs/spatialHadoop/core/Rectangle.java
+++ b/src/main/java/edu/umn/cs/spatialHadoop/core/Rectangle.java
@@ -116,6 +116,21 @@ public class Rectangle implements Shape, WritableComparable<Rectangle> {
   }
 
   @Override
+  public int hashCode() {
+    int result;
+    long temp;
+    temp = Double.doubleToLongBits(this.x1);
+    result = (int) (temp ^ temp >>> 32);
+    temp = Double.doubleToLongBits(this.y1);
+    result = 31 * result + (int) (temp ^ temp >>> 32);
+    temp = Double.doubleToLongBits(this.x2);
+    result = 31 * result + (int) (temp ^ temp >>> 32);
+    temp = Double.doubleToLongBits(this.y2);
+    result = 31 * result + (int) (temp ^ temp >>> 32);
+    return result;
+  }
+
+  @Override
   public double distanceTo(double px, double py) {
     return this.getMaxDistanceTo(px, py);
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “equals(Object obj)" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.